### PR TITLE
fix: Course 엔티티의 departments 필드명 불일치 수정

### DIFF
--- a/app/backend/catalog-service/src/main/java/com/uniplan/catalog/domain/course/repository/CourseSpecification.java
+++ b/app/backend/catalog-service/src/main/java/com/uniplan/catalog/domain/course/repository/CourseSpecification.java
@@ -58,7 +58,7 @@ public class CourseSpecification {
 
             // Department filter (join)
             if (request.getDepartmentCode() != null && !request.getDepartmentCode().isBlank()) {
-                Join<Object, Object> department = root.join("department");
+                Join<Object, Object> department = root.join("departments");
                 predicates.add(criteriaBuilder.equal(department.get("code"), request.getDepartmentCode()));
             }
 

--- a/app/backend/catalog-service/src/test/java/com/uniplan/catalog/domain/course/controller/CourseControllerTest.java
+++ b/app/backend/catalog-service/src/test/java/com/uniplan/catalog/domain/course/controller/CourseControllerTest.java
@@ -106,7 +106,7 @@ class CourseControllerTest {
             .classroom("테스트강의실")
             .campus(campus)
             .notes("테스트 과목")
-            .department(testDepartment)
+            .departments(java.util.List.of(testDepartment))
             .courseType(testCourseType)
             .build();
 


### PR DESCRIPTION
Course 엔티티는 ManyToMany 관계로 departments (복수형)를 사용하는데, 테스트 코드와 Specification에서 department (단수형)를 참조하여 오류 발생.

변경사항:
- CourseControllerTest: .department() → .departments(List.of())로 수정
- CourseSpecification: join("department") → join("departments")로 수정